### PR TITLE
Checkbox task lists (`- [x]`/`- [ ]`) lose check state — converted to plain `bulletList` instead of `taskList`

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -29,6 +29,8 @@ import { CodeBlockConverter } from './adf-to-markdown/nodes/CodeBlockConverter.j
 import { BulletListConverter } from './adf-to-markdown/nodes/BulletListConverter.js';
 import { OrderedListConverter } from './adf-to-markdown/nodes/OrderedListConverter.js';
 import { ListItemConverter } from './adf-to-markdown/nodes/ListItemConverter.js';
+import { TaskListConverter } from './adf-to-markdown/nodes/TaskListConverter.js';
+import { TaskItemConverter } from './adf-to-markdown/nodes/TaskItemConverter.js';
 import { MediaConverter } from './adf-to-markdown/nodes/MediaConverter.js';
 import { MediaSingleConverter } from './adf-to-markdown/nodes/MediaSingleConverter.js';
 import { TableConverter } from './adf-to-markdown/nodes/TableConverter.js';
@@ -275,6 +277,8 @@ export class Parser {
       new BulletListConverter(),
       new OrderedListConverter(),
       new ListItemConverter(),
+      new TaskListConverter(),
+      new TaskItemConverter(),
       new MediaConverter(),
       new MediaSingleConverter(),
       new TableConverter(),

--- a/src/parser/adf-to-markdown/nodes/TaskItemConverter.ts
+++ b/src/parser/adf-to-markdown/nodes/TaskItemConverter.ts
@@ -1,0 +1,68 @@
+/**
+ * @file Task Item node converter
+ * @see https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/taskItem/
+ */
+
+import type { NodeConverter, ConversionContext } from '../../types';
+import type { ADFNode, TaskItemNode } from '../../../types';
+
+/**
+ * Task Item Node Converter
+ *
+ * Official Documentation:
+ * @see https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/taskItem/
+ *
+ * Purpose:
+ * Task Item nodes represent individual checkbox items within a task list
+ *
+ * ADF Schema:
+ * ```json
+ * {
+ *   "type": "taskItem",
+ *   "attrs": { "localId": "unique-id", "state": "DONE" },
+ *   "content": [
+ *     { "type": "text", "text": "Task content" }
+ *   ]
+ * }
+ * ```
+ *
+ * Markdown Representation:
+ * ```markdown
+ * - [x] Task content (for DONE)
+ * - [ ] Task content (for TODO)
+ * ```
+ */
+export class TaskItemConverter implements NodeConverter {
+  nodeType = 'taskItem';
+
+  toMarkdown(node: ADFNode, context: ConversionContext): string {
+    const taskItemNode = node as TaskItemNode;
+
+    const prefix = taskItemNode.attrs?.state === 'DONE' ? '- [x] ' : '- [ ] ';
+
+    if (!taskItemNode.content || taskItemNode.content.length === 0) {
+      return prefix;
+    }
+
+    // taskItem has inline nodes directly (not paragraph-wrapped)
+    const content = taskItemNode.content.map(child => {
+      const converter = context.options.registry?.getNodeConverter(child.type);
+      if (!converter) return '';
+      return converter.toMarkdown(child, context);
+    }).filter(c => c.length > 0).join('');
+
+    // Handle multi-line content with 6-space indentation (aligns with content after '- [x] ')
+    const lines = content.split('\n');
+    const indentedLines = lines.map((line, index) => {
+      if (index === 0) {
+        return `${prefix}${line}`;
+      } else if (line.trim().length > 0) {
+        return `      ${line}`; // 6-space indent for continuation
+      } else {
+        return line; // Keep empty lines as-is
+      }
+    });
+
+    return indentedLines.join('\n');
+  }
+}

--- a/src/parser/adf-to-markdown/nodes/TaskListConverter.ts
+++ b/src/parser/adf-to-markdown/nodes/TaskListConverter.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Task List node converter
+ * @see https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/taskList/
+ */
+
+import type { NodeConverter, ConversionContext } from '../../types';
+import type { ADFNode, TaskListNode } from '../../../types';
+
+/**
+ * Task List Node Converter
+ *
+ * Official Documentation:
+ * @see https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/taskList/
+ *
+ * Purpose:
+ * Task List nodes create checkbox task lists with TODO/DONE states
+ *
+ * ADF Schema:
+ * ```json
+ * {
+ *   "type": "taskList",
+ *   "attrs": { "localId": "unique-id" },
+ *   "content": [
+ *     {
+ *       "type": "taskItem",
+ *       "attrs": { "localId": "unique-id-1", "state": "DONE" },
+ *       "content": [{ "type": "text", "text": "Completed task" }]
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * Markdown Representation:
+ * ```markdown
+ * - [x] Completed task
+ * - [ ] Pending task
+ * ```
+ */
+export class TaskListConverter implements NodeConverter {
+  nodeType = 'taskList';
+
+  toMarkdown(node: ADFNode, context: ConversionContext): string {
+    const taskListNode = node as TaskListNode;
+
+    if (!taskListNode.content || taskListNode.content.length === 0) {
+      return '';
+    }
+
+    const taskItems = taskListNode.content.map(taskItem => {
+      const itemConverter = context.options.registry?.getNodeConverter('taskItem');
+      if (itemConverter) {
+        return itemConverter.toMarkdown(taskItem, {
+          ...context,
+          depth: context.depth + 1,
+          parent: taskListNode
+        });
+      }
+      return '';
+    }).filter(item => item.length > 0);
+
+    return taskItems.join('\n');
+  }
+}

--- a/src/parser/engines/AdfToMarkdownEngine.ts
+++ b/src/parser/engines/AdfToMarkdownEngine.ts
@@ -17,6 +17,8 @@ import { CodeBlockConverter } from '../adf-to-markdown/nodes/CodeBlockConverter.
 import { BulletListConverter } from '../adf-to-markdown/nodes/BulletListConverter.js';
 import { OrderedListConverter } from '../adf-to-markdown/nodes/OrderedListConverter.js';
 import { ListItemConverter } from '../adf-to-markdown/nodes/ListItemConverter.js';
+import { TaskListConverter } from '../adf-to-markdown/nodes/TaskListConverter.js';
+import { TaskItemConverter } from '../adf-to-markdown/nodes/TaskItemConverter.js';
 import { MediaConverter } from '../adf-to-markdown/nodes/MediaConverter.js';
 import { MediaSingleConverter } from '../adf-to-markdown/nodes/MediaSingleConverter.js';
 import { TableConverter } from '../adf-to-markdown/nodes/TableConverter.js';
@@ -220,6 +222,8 @@ export class AdfToMarkdownEngine {
       new BulletListConverter(),
       new OrderedListConverter(),
       new ListItemConverter(),
+      new TaskListConverter(),
+      new TaskItemConverter(),
       new MediaConverter(),
       new MediaSingleConverter(),
       new TableConverter(),

--- a/src/parser/markdown-to-adf/ASTBuilder.ts
+++ b/src/parser/markdown-to-adf/ASTBuilder.ts
@@ -4,7 +4,7 @@
  * @author Extended ADF Parser
  */
 
-import { Token, TokenType, ADFMetadata } from './types.js';
+import { Token, TokenType, ADFMetadata, ListItemToken } from './types.js';
 import { ADFDocument, ADFNode, ADFMark } from '../../types/adf.types.js';
 import type { Root } from 'mdast';
 import type { AdfFenceNode } from '../remark/adf-from-markdown.js';
@@ -235,7 +235,38 @@ export class ASTBuilder {
     const listToken = token as any; // ListToken
     const isOrdered = listToken.ordered || false;
     const customAttrs = this.extractCustomAttributes(token.metadata);
-    
+
+    // Check if any child token has a checkbox (checked property)
+    const children = token.children || [];
+    const hasCheckbox = children.some((child: any) =>
+      (child as ListItemToken).checked !== undefined && (child as ListItemToken).checked !== null
+    );
+
+    // If checkbox list and not ordered, attempt taskList conversion
+    if (hasCheckbox && !isOrdered) {
+      // Validate all checkbox items have simple content (single paragraph child only)
+      const allSimple = children.every((child: any) => {
+        return this.isTokenItemSimple(child);
+      });
+
+      if (allSimple) {
+        return {
+          type: 'taskList',
+          attrs: { localId: crypto.randomUUID() },
+          content: children.map((child: any) => this.convertTaskItem(child as ListItemToken))
+        };
+      }
+      // Fall back to bulletList if any item has complex content
+      // Re-prepend checkbox syntax to content so it's not lost in the fallback path
+      for (const child of children) {
+        const itemToken = child as ListItemToken;
+        if (itemToken.checked !== undefined && itemToken.checked !== null) {
+          const prefix = itemToken.checked ? '[x] ' : '[ ] ';
+          itemToken.content = prefix + itemToken.content;
+        }
+      }
+    }
+
     const attrs: any = {};
     if (isOrdered && listToken.start && listToken.start !== 1) {
       attrs.order = listToken.start;
@@ -252,6 +283,42 @@ export class ASTBuilder {
     }
 
     return node;
+  }
+
+  /**
+   * Check if a token-path list item has simple content (single paragraph child only)
+   */
+  private isTokenItemSimple(token: Token): boolean {
+    if (!token.children || token.children.length === 0) return true;
+    // Simple: single paragraph child with no further block nesting
+    if (token.children.length === 1 && token.children[0].type === 'paragraph') return true;
+    // Complex: multiple children, or non-paragraph children (lists, code blocks, etc.)
+    return false;
+  }
+
+  /**
+   * Convert a ListItemToken with checked property to a taskItem ADF node (token path)
+   */
+  private convertTaskItem(token: ListItemToken): ADFNode {
+    const state = token.checked ? 'DONE' : 'TODO';
+
+    // Extract inline content from the single paragraph child
+    let content: ADFNode[] = [];
+    if (token.children && token.children.length === 1 && token.children[0].type === 'paragraph') {
+      const paragraphToken = token.children[0];
+      // Use inline tokens if available, otherwise parse content string
+      content = paragraphToken.children && paragraphToken.children.length > 0
+        ? this.convertInlineTokensToNodes(paragraphToken.children)
+        : this.convertInlineContent(paragraphToken.content);
+    } else if (token.content) {
+      content = this.convertInlineContent(token.content);
+    }
+
+    return {
+      type: 'taskItem',
+      attrs: { localId: crypto.randomUUID(), state },
+      content
+    };
   }
 
   private convertListItem(token: Token): ADFNode {
@@ -1628,10 +1695,52 @@ export class ASTBuilder {
   }
 
   private convertMdastList(node: any): ADFNode {
+    // Detect checkbox/task list: any child with checked !== null && checked !== undefined
+    if (!node.ordered && node.children?.some((child: any) => child.checked !== null && child.checked !== undefined)) {
+      // Validate all checkbox items have simple content (single paragraph child only)
+      const allSimple = node.children.every((child: any) => this.isCheckboxItemSimple(child));
+      if (allSimple) {
+        return {
+          type: 'taskList',
+          attrs: { localId: crypto.randomUUID() },
+          content: node.children.map((child: any) => this.convertMdastTaskItem(child))
+        };
+      }
+      // Fall back to bulletList if any item has complex content
+    }
+
     return {
       type: node.ordered ? 'orderedList' : 'bulletList',
       ...(node.start && node.start !== 1 && { attrs: { order: node.start } }),
       content: this.convertMdastNodesToADF(node.children)
+    };
+  }
+
+  /**
+   * Check if a checkbox list item has simple content (single paragraph child only).
+   * Items with multiple paragraphs, nested lists, code blocks, etc. cannot be taskItems
+   * since ADF taskItem only allows inline content.
+   */
+  private isCheckboxItemSimple(node: any): boolean {
+    if (!node.children || node.children.length === 0) return true;
+    return node.children.length === 1 && node.children[0].type === 'paragraph';
+  }
+
+  /**
+   * Convert an mdast listItem with checked state to an ADF taskItem.
+   * Extracts inline children from the first paragraph child since taskItem
+   * content is inline nodes directly (not wrapped in paragraph).
+   */
+  private convertMdastTaskItem(node: any): ADFNode {
+    const state = node.checked ? 'DONE' : 'TODO';
+    const inlineContent = node.children?.[0]?.children
+      ? this.convertMdastInlineNodes(node.children[0].children)
+      : [];
+
+    return {
+      type: 'taskItem',
+      attrs: { localId: crypto.randomUUID(), state },
+      content: inlineContent
     };
   }
 
@@ -2401,11 +2510,43 @@ export class ASTBuilder {
       };
     }
     
-    // 7. Bullet list
+    // 7. Checkbox task list (before regular bullet list)
+    const hasCheckboxPattern = lines.some(line => /^\s*[-*+]\s+\[(x|X| )\]\s/.test(line));
+    if (hasCheckboxPattern) {
+      // All items in this block must be simple single-line items for taskList
+      const allBulletLines = lines.filter(line => /^\s*[-*+]\s/.test(line));
+      const allSimple = allBulletLines.every(line => /^\s*[-*+]\s+\[(x|X| )\]\s/.test(line));
+
+      if (allSimple) {
+        const taskItems: ADFNode[] = [];
+
+        for (const line of lines) {
+          const taskMatch = line.match(/^\s*[-*+]\s+\[(x|X| )\]\s*(.*)$/);
+          if (taskMatch) {
+            const state = (taskMatch[1] === 'x' || taskMatch[1] === 'X') ? 'DONE' : 'TODO';
+            const itemContent = taskMatch[2] ? this.parseInlineContentWithSocialElements(taskMatch[2]) : [];
+            taskItems.push({
+              type: 'taskItem',
+              attrs: { localId: crypto.randomUUID(), state },
+              content: itemContent
+            });
+          }
+        }
+
+        return {
+          type: 'taskList',
+          attrs: { localId: crypto.randomUUID() },
+          content: taskItems
+        };
+      }
+      // Fall through to bulletList if items are complex
+    }
+
+    // 8. Bullet list
     const isBulletList = lines.some(line => /^\s*[-*+]\s/.test(line));
     if (isBulletList) {
       const listItems: ADFNode[] = [];
-      
+
       for (const line of lines) {
         const listMatch = line.match(/^\s*[-*+]\s+(.+)$/);
         if (listMatch) {
@@ -2426,13 +2567,13 @@ export class ASTBuilder {
       };
     }
     
-    // 8. Table
+    // 9. Table
     const isTableBlock = lines.some(line => /^\s*\|.*\|\s*$/.test(line));
     if (isTableBlock) {
       return this.parseTableFromLines(lines);
     }
-    
-    // 9. Default: paragraph
+
+    // 10. Default: paragraph
     return {
       type: 'paragraph',
       content: this.parseInlineContentWithSocialElements(blockContent)

--- a/src/parser/markdown-to-adf/MarkdownTokenizer.ts
+++ b/src/parser/markdown-to-adf/MarkdownTokenizer.ts
@@ -4,7 +4,7 @@
  * @author Extended ADF Parser
  */
 
-import { Token, TokenType, Position, ParsingContext, TokenizeOptions, ListToken, TableToken, FenceToken, ADFMetadata } from './types.js';
+import { Token, TokenType, Position, ParsingContext, TokenizeOptions, ListToken, ListItemToken, TableToken, FenceToken, ADFMetadata } from './types.js';
 
 export class MarkdownTokenizer {
   private lines: string[] = [];
@@ -497,21 +497,30 @@ export class MarkdownTokenizer {
     // Get first line and extract content
     const firstLine = this.consumeLine();
     raw += firstLine + '\n';
-    
+
     const match = firstLine.match(/^\s*(?:[-*+]|\d+\.)\s+(.*)$/);
-    const content = match?.[1] || firstLine;
+    let content = match?.[1] || firstLine;
+
+    // Detect checkbox syntax: [x], [X], or [ ]
+    let checked: boolean | undefined;
+    const checkboxMatch = content.match(/^\[(x|X| )\]\s/);
+    if (checkboxMatch) {
+      checked = checkboxMatch[1] === 'x' || checkboxMatch[1] === 'X';
+      content = content.slice(checkboxMatch[0].length);
+    }
+
     lines.push(content);
 
     // Collect continuation lines
     while (this.currentLineIndex < this.lines.length) {
       const line = this.getCurrentLine();
-      
+
       // Stop if we hit another list item at same or lower level
       if (this.isList(line)) break;
-      
+
       // Stop if we hit a completely unindented line
       if (line.trim() && !line.startsWith('  ')) break;
-      
+
       // Include indented continuation
       if (line.startsWith('  ') || !line.trim()) {
         lines.push(line.slice(2)); // Remove 2-space indent
@@ -533,8 +542,9 @@ export class MarkdownTokenizer {
       content: lines.join('\n'),
       children,
       position: startPos,
-      raw: raw.trimEnd()
-    };
+      raw: raw.trimEnd(),
+      ...(checked !== undefined && { checked })
+    } as ListItemToken;
   }
 
   private parseBlockquote(): Token {

--- a/src/parser/markdown-to-adf/types.ts
+++ b/src/parser/markdown-to-adf/types.ts
@@ -62,6 +62,11 @@ export interface ListToken extends Token {
   tight: boolean;
 }
 
+export interface ListItemToken extends Token {
+  type: 'listItem';
+  checked?: boolean; // true = [x], false = [ ], undefined = regular list item
+}
+
 export interface TableToken extends Token {
   type: 'table';
   columnAlignments: ('left' | 'center' | 'right' | null)[];

--- a/src/types/adf.types.ts
+++ b/src/types/adf.types.ts
@@ -76,6 +76,18 @@ export interface ListItemNode extends ADFNode {
   content?: ADFNode[];
 }
 
+export interface TaskListNode extends ADFNode {
+  type: 'taskList';
+  attrs: { localId: string };
+  content: TaskItemNode[];
+}
+
+export interface TaskItemNode extends ADFNode {
+  type: 'taskItem';
+  attrs: { localId: string; state: 'TODO' | 'DONE' };
+  content?: ADFNode[];  // inline nodes directly, no paragraph wrapper
+}
+
 export interface MediaNode extends ADFNode {
   type: 'media';
   attrs: {

--- a/src/validators/schemas/adf-schema.json
+++ b/src/validators/schemas/adf-schema.json
@@ -34,6 +34,7 @@
           "type": "string",
           "enum": [
             "paragraph", "heading", "blockquote", "bulletList", "orderedList", "listItem",
+            "taskList", "taskItem",
             "codeBlock", "panel", "expand", "table", "tableRow", "tableHeader", "tableCell",
             "mediaSingle", "mediaGroup", "media", "rule", "text", "hardBreak",
             "mention", "emoji", "status", "date", "inlineCard"
@@ -124,6 +125,35 @@
                 "type": "object",
                 "properties": {
                   "order": { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "taskList" } } },
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["localId"],
+                "properties": {
+                  "localId": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "taskItem" } } },
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["localId", "state"],
+                "properties": {
+                  "localId": { "type": "string" },
+                  "state": { "type": "string", "enum": ["TODO", "DONE"] }
                 }
               }
             }

--- a/tests/unit/nodes/TaskItemConverter.test.ts
+++ b/tests/unit/nodes/TaskItemConverter.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @file Tests for TaskItemConverter
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { TaskItemConverter } from '../../../src/parser/adf-to-markdown/nodes/TaskItemConverter';
+import type { ConversionContext } from '../../../src/parser/types';
+import type { TaskItemNode } from '../../../src/types';
+
+describe('TaskItemConverter', () => {
+  const converter = new TaskItemConverter();
+
+  const mockTextConverter = {
+    nodeType: 'text',
+    toMarkdown: jest.fn()
+  };
+
+  const mockContext: ConversionContext = {
+    convertChildren: jest.fn(),
+    depth: 0,
+    options: {
+      registry: {
+        getNodeConverter: jest.fn().mockReturnValue(mockTextConverter)
+      } as any
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('nodeType', () => {
+    it('should have correct nodeType', () => {
+      expect(converter.nodeType).toBe('taskItem');
+    });
+  });
+
+  describe('toMarkdown', () => {
+    it('should convert DONE state with correct prefix', () => {
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'DONE' },
+        content: [{ type: 'text', text: 'Completed task' }]
+      };
+
+      (mockTextConverter.toMarkdown as jest.Mock).mockReturnValue('Completed task');
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [x] Completed task');
+    });
+
+    it('should convert TODO state with correct prefix', () => {
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'TODO' },
+        content: [{ type: 'text', text: 'Pending task' }]
+      };
+
+      (mockTextConverter.toMarkdown as jest.Mock).mockReturnValue('Pending task');
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [ ] Pending task');
+    });
+
+    it('should handle inline content directly (not paragraph-wrapped)', () => {
+      // taskItem content is inline nodes (text, emoji, mention, etc.), not paragraphs
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'DONE' },
+        content: [
+          { type: 'text', text: 'Direct inline text' }
+        ]
+      };
+
+      (mockTextConverter.toMarkdown as jest.Mock).mockReturnValue('Direct inline text');
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [x] Direct inline text');
+      // Verify it looked up a converter for the text node, not a paragraph converter
+      expect(mockContext.options.registry?.getNodeConverter).toHaveBeenCalledWith('text');
+    });
+
+    it('should handle multiple inline nodes', () => {
+      const mockStrongConverter = {
+        nodeType: 'text',
+        toMarkdown: jest.fn()
+      };
+
+      const contextWithMultipleConverters: ConversionContext = {
+        ...mockContext,
+        options: {
+          registry: {
+            getNodeConverter: jest.fn().mockImplementation((type: string) => {
+              return mockStrongConverter;
+            })
+          } as any
+        }
+      };
+
+      mockStrongConverter.toMarkdown
+        .mockReturnValueOnce('Bold text')
+        .mockReturnValueOnce(' and ')
+        .mockReturnValueOnce('more text');
+
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'TODO' },
+        content: [
+          { type: 'text', text: 'Bold text', marks: [{ type: 'strong' }] },
+          { type: 'text', text: ' and ' },
+          { type: 'text', text: 'more text' }
+        ]
+      };
+
+      const result = converter.toMarkdown(node, contextWithMultipleConverters);
+      expect(result).toBe('- [ ] Bold text and more text');
+    });
+
+    it('should handle empty content', () => {
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'TODO' },
+        content: []
+      };
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [ ] ');
+    });
+
+    it('should handle undefined content', () => {
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'DONE' }
+      } as TaskItemNode;
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [x] ');
+    });
+
+    it('should handle multi-line content with proper indentation', () => {
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'DONE' },
+        content: [{ type: 'text', text: 'First line\nSecond line\nThird line' }]
+      };
+
+      (mockTextConverter.toMarkdown as jest.Mock).mockReturnValue('First line\nSecond line\nThird line');
+
+      const result = converter.toMarkdown(node, mockContext);
+      // 6-space indent for continuation lines to align with content after '- [x] '
+      expect(result).toBe('- [x] First line\n      Second line\n      Third line');
+    });
+
+    it('should preserve empty lines in multi-line content', () => {
+      const node: TaskItemNode = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1', state: 'TODO' },
+        content: [{ type: 'text', text: 'Line 1\n\nLine 3' }]
+      };
+
+      (mockTextConverter.toMarkdown as jest.Mock).mockReturnValue('Line 1\n\nLine 3');
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [ ] Line 1\n\n      Line 3');
+    });
+
+    it('should default to TODO when state is not DONE', () => {
+      // Edge case: attrs missing state entirely
+      const node = {
+        type: 'taskItem',
+        attrs: { localId: 'test-1' },
+        content: [{ type: 'text', text: 'Task' }]
+      } as any;
+
+      (mockTextConverter.toMarkdown as jest.Mock).mockReturnValue('Task');
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [ ] Task');
+    });
+  });
+});

--- a/tests/unit/nodes/TaskListConverter.test.ts
+++ b/tests/unit/nodes/TaskListConverter.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @file Tests for TaskListConverter
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { TaskListConverter } from '../../../src/parser/adf-to-markdown/nodes/TaskListConverter';
+import type { ConversionContext } from '../../../src/parser/types';
+import type { TaskListNode } from '../../../src/types';
+
+describe('TaskListConverter', () => {
+  const converter = new TaskListConverter();
+
+  const mockTaskItemConverter = {
+    nodeType: 'taskItem',
+    toMarkdown: jest.fn().mockImplementation((node: any) => {
+      const prefix = node.attrs?.state === 'DONE' ? '- [x] ' : '- [ ] ';
+      const text = node.content?.[0]?.text || 'item';
+      return `${prefix}${text}`;
+    })
+  };
+
+  const mockContext: ConversionContext = {
+    convertChildren: jest.fn(),
+    depth: 0,
+    options: {
+      registry: {
+        getNodeConverter: jest.fn().mockReturnValue(mockTaskItemConverter)
+      } as any
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('nodeType', () => {
+    it('should have correct nodeType', () => {
+      expect(converter.nodeType).toBe('taskList');
+    });
+  });
+
+  describe('toMarkdown', () => {
+    it('should convert single DONE taskItem', () => {
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: [
+          {
+            type: 'taskItem',
+            attrs: { localId: 'test-item-1', state: 'DONE' },
+            content: [{ type: 'text', text: 'Completed task' }]
+          }
+        ]
+      };
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [x] Completed task');
+      expect(mockTaskItemConverter.toMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it('should convert single TODO taskItem', () => {
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: [
+          {
+            type: 'taskItem',
+            attrs: { localId: 'test-item-1', state: 'TODO' },
+            content: [{ type: 'text', text: 'Pending task' }]
+          }
+        ]
+      };
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [ ] Pending task');
+      expect(mockTaskItemConverter.toMarkdown).toHaveBeenCalledTimes(1);
+    });
+
+    it('should convert mixed state taskList', () => {
+      mockTaskItemConverter.toMarkdown
+        .mockReturnValueOnce('- [x] Done task')
+        .mockReturnValueOnce('- [ ] Todo task')
+        .mockReturnValueOnce('- [x] Another done');
+
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: [
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-1', state: 'DONE' },
+            content: [{ type: 'text', text: 'Done task' }]
+          },
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-2', state: 'TODO' },
+            content: [{ type: 'text', text: 'Todo task' }]
+          },
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-3', state: 'DONE' },
+            content: [{ type: 'text', text: 'Another done' }]
+          }
+        ]
+      };
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [x] Done task\n- [ ] Todo task\n- [x] Another done');
+      expect(mockTaskItemConverter.toMarkdown).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle empty taskList', () => {
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: []
+      };
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('');
+    });
+
+    it('should handle taskList with undefined content', () => {
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' }
+      } as TaskListNode;
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('');
+    });
+
+    it('should filter out empty items', () => {
+      mockTaskItemConverter.toMarkdown
+        .mockReturnValueOnce('- [x] First task')
+        .mockReturnValueOnce('')
+        .mockReturnValueOnce('- [ ] Third task');
+
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: [
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-1', state: 'DONE' },
+            content: [{ type: 'text', text: 'First task' }]
+          },
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-2', state: 'TODO' },
+            content: []
+          },
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-3', state: 'TODO' },
+            content: [{ type: 'text', text: 'Third task' }]
+          }
+        ]
+      };
+
+      const result = converter.toMarkdown(node, mockContext);
+      expect(result).toBe('- [x] First task\n- [ ] Third task');
+    });
+
+    it('should handle missing taskItem converter (fallback)', () => {
+      const contextWithoutConverter: ConversionContext = {
+        ...mockContext,
+        options: {
+          registry: {
+            getNodeConverter: jest.fn().mockReturnValue(null)
+          } as any
+        }
+      };
+
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: [
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-1', state: 'DONE' },
+            content: [{ type: 'text', text: 'Task' }]
+          }
+        ]
+      };
+
+      const result = converter.toMarkdown(node, contextWithoutConverter);
+      expect(result).toBe('');
+    });
+
+    it('should pass correct context to taskItem converter', () => {
+      const node: TaskListNode = {
+        type: 'taskList',
+        attrs: { localId: 'test-list-1' },
+        content: [
+          {
+            type: 'taskItem',
+            attrs: { localId: 'item-1', state: 'DONE' },
+            content: [{ type: 'text', text: 'Test task' }]
+          }
+        ]
+      };
+
+      converter.toMarkdown(node, mockContext);
+
+      expect(mockTaskItemConverter.toMarkdown).toHaveBeenCalledWith(
+        node.content![0],
+        {
+          ...mockContext,
+          depth: mockContext.depth + 1,
+          parent: node
+        }
+      );
+    });
+  });
+});

--- a/tests/unit/parser/ASTBuilder.task-list.test.ts
+++ b/tests/unit/parser/ASTBuilder.task-list.test.ts
@@ -1,0 +1,418 @@
+/**
+ * @file ASTBuilder.task-list.test.ts
+ * @description Tests for ASTBuilder task-list conversion in both mdast and token paths
+ *
+ * The ASTBuilder has two conversion paths:
+ *   1. mdast path: buildADFFromMdast -> convertMdastList / convertMdastTaskItem
+ *   2. token path: buildADF -> convertList / convertTaskItem
+ */
+
+import { ASTBuilder } from '../../../src/parser/markdown-to-adf/ASTBuilder.js';
+import type { ListItemToken, Token } from '../../../src/parser/markdown-to-adf/types.js';
+
+describe('ASTBuilder - Task List Conversion', () => {
+  let builder: ASTBuilder;
+
+  beforeEach(() => {
+    builder = new ASTBuilder();
+  });
+
+  // ---------------------------------------------------------------
+  // Section 1: mdast path tests (buildADFFromMdast / convertMdastList)
+  // ---------------------------------------------------------------
+  describe('mdast path: convertMdastList / convertMdastTaskItem', () => {
+    /**
+     * Helper to build a minimal mdast tree with a list node.
+     * remark-gfm represents checkbox items as listItem nodes with
+     * `checked: true|false` and paragraph children whose text does
+     * NOT include the `[x]` prefix.
+     */
+    function mdastList(items: Array<{ checked?: boolean | null; text: string; children?: any[] }>, ordered = false): any {
+      return {
+        type: 'root',
+        children: [{
+          type: 'list',
+          ordered,
+          start: ordered ? 1 : null,
+          spread: false,
+          children: items.map(item => ({
+            type: 'listItem',
+            checked: item.checked ?? null,
+            spread: false,
+            children: item.children ?? [{
+              type: 'paragraph',
+              children: [{ type: 'text', value: item.text }]
+            }]
+          }))
+        }]
+      };
+    }
+
+    it('should convert "- [x] Done" to taskList with taskItem state=DONE', () => {
+      const tree = mdastList([{ checked: true, text: 'Done' }]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      expect(adf.content).toHaveLength(1);
+      const taskList = adf.content[0];
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.attrs).toBeDefined();
+      expect(taskList.attrs!.localId).toBeDefined();
+      expect(taskList.content).toHaveLength(1);
+
+      const taskItem = taskList.content![0];
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs!.state).toBe('DONE');
+    });
+
+    it('should convert "- [ ] Todo" to taskItem with state=TODO', () => {
+      const tree = mdastList([{ checked: false, text: 'Todo' }]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      const taskList = adf.content[0];
+      expect(taskList.type).toBe('taskList');
+      const taskItem = taskList.content![0];
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs!.state).toBe('TODO');
+    });
+
+    it('should convert mixed checkbox list to single taskList with correct states', () => {
+      const tree = mdastList([
+        { checked: true, text: 'A' },
+        { checked: false, text: 'B' }
+      ]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      expect(adf.content).toHaveLength(1);
+      const taskList = adf.content[0];
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.content).toHaveLength(2);
+
+      expect(taskList.content![0].attrs!.state).toBe('DONE');
+      expect(taskList.content![1].attrs!.state).toBe('TODO');
+    });
+
+    it('should keep regular bullet list (no checkboxes) as bulletList', () => {
+      const tree = mdastList([
+        { text: 'item one' },
+        { text: 'item two' }
+      ]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      expect(adf.content).toHaveLength(1);
+      expect(adf.content[0].type).toBe('bulletList');
+    });
+
+    it('taskItem content should be inline nodes (no paragraph wrapper)', () => {
+      const tree = mdastList([{ checked: true, text: 'Simple text' }]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      const taskItem = adf.content[0].content![0];
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.content).toBeDefined();
+
+      // Should NOT have paragraph wrapper
+      const hasParagraph = taskItem.content!.some(n => n.type === 'paragraph');
+      expect(hasParagraph).toBe(false);
+
+      // Should have inline text node
+      const textNode = taskItem.content!.find(n => n.type === 'text');
+      expect(textNode).toBeDefined();
+      expect(textNode!.text).toBe('Simple text');
+    });
+
+    it('should generate non-empty, unique localId attributes', () => {
+      const tree = mdastList([
+        { checked: true, text: 'Task 1' },
+        { checked: false, text: 'Task 2' }
+      ]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      const taskList = adf.content[0];
+      expect(typeof taskList.attrs!.localId).toBe('string');
+      expect((taskList.attrs!.localId as string).length).toBeGreaterThan(0);
+
+      const ids: string[] = [taskList.attrs!.localId as string];
+      for (const item of taskList.content!) {
+        expect(typeof item.attrs!.localId).toBe('string');
+        expect((item.attrs!.localId as string).length).toBeGreaterThan(0);
+        ids.push(item.attrs!.localId as string);
+      }
+
+      // All IDs should be unique
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('should preserve inline formatting (bold text with strong mark)', () => {
+      const tree: any = {
+        type: 'root',
+        children: [{
+          type: 'list',
+          ordered: false,
+          children: [{
+            type: 'listItem',
+            checked: true,
+            children: [{
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'strong',
+                  children: [{ type: 'text', value: 'bold' }]
+                },
+                { type: 'text', value: ' text' }
+              ]
+            }]
+          }]
+        }]
+      };
+
+      const adf = builder.buildADFFromMdast(tree);
+      const taskItem = adf.content[0].content![0];
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs!.state).toBe('DONE');
+      expect(taskItem.content).toBeDefined();
+
+      // Find bold node (text with strong mark)
+      const boldNode = taskItem.content!.find(
+        n => n.type === 'text' && n.marks?.some(m => m.type === 'strong')
+      );
+      expect(boldNode).toBeDefined();
+      expect(boldNode!.text).toBe('bold');
+    });
+
+    it('should handle uppercase X as checked (via mdast checked property)', () => {
+      // In mdast, remark-gfm normalizes [X] and [x] to checked: true
+      const tree = mdastList([{ checked: true, text: 'Done' }]);
+      const adf = builder.buildADFFromMdast(tree);
+
+      const taskItem = adf.content[0].content![0];
+      expect(taskItem.attrs!.state).toBe('DONE');
+    });
+
+    it('should fall back to bulletList when checkbox item has nested sub-list', () => {
+      const tree: any = {
+        type: 'root',
+        children: [{
+          type: 'list',
+          ordered: false,
+          children: [{
+            type: 'listItem',
+            checked: true,
+            children: [
+              { type: 'paragraph', children: [{ type: 'text', value: 'Task with sub-list' }] },
+              {
+                type: 'list',
+                ordered: false,
+                children: [{
+                  type: 'listItem',
+                  checked: null,
+                  children: [{ type: 'paragraph', children: [{ type: 'text', value: 'nested item' }] }]
+                }]
+              }
+            ]
+          }]
+        }]
+      };
+
+      const adf = builder.buildADFFromMdast(tree);
+      expect(adf.content).toHaveLength(1);
+      // Should fall back to bulletList since item has complex content (nested list)
+      expect(adf.content[0].type).toBe('bulletList');
+    });
+
+    it('should fall back to bulletList when checkbox item has multiple paragraphs', () => {
+      const tree: any = {
+        type: 'root',
+        children: [{
+          type: 'list',
+          ordered: false,
+          children: [{
+            type: 'listItem',
+            checked: true,
+            children: [
+              { type: 'paragraph', children: [{ type: 'text', value: 'First para' }] },
+              { type: 'paragraph', children: [{ type: 'text', value: 'Second para' }] }
+            ]
+          }]
+        }]
+      };
+
+      const adf = builder.buildADFFromMdast(tree);
+      expect(adf.content[0].type).toBe('bulletList');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Section 2: token path tests (buildADF -> convertList / convertTaskItem)
+  // ---------------------------------------------------------------
+  describe('token path: convertList / convertTaskItem', () => {
+    /**
+     * Helper to build token structures that mimic what MarkdownTokenizer produces.
+     * The tokenizer produces a `list` token with `listItem` children.
+     * Checkbox items have a `checked` property on the listItem token.
+     * Each listItem has a `paragraph` child token with the item text.
+     */
+    function listToken(items: Array<{ checked?: boolean; text: string }>, ordered = false): Token[] {
+      const pos = { line: 1, column: 1, offset: 0 };
+      return [{
+        type: 'list' as const,
+        ordered,
+        start: ordered ? 1 : undefined,
+        tight: true,
+        content: '',
+        position: pos,
+        raw: '',
+        children: items.map(item => {
+          const token: any = {
+            type: 'listItem' as const,
+            content: item.text,
+            position: pos,
+            raw: '',
+            children: [{
+              type: 'paragraph' as const,
+              content: item.text,
+              position: pos,
+              raw: '',
+            }]
+          };
+          if (item.checked !== undefined) {
+            token.checked = item.checked;
+          }
+          return token;
+        })
+      } as any];
+    }
+
+    it('should convert token with checked: true to taskItem state=DONE', () => {
+      const tokens = listToken([{ checked: true, text: 'Done' }]);
+      const adf = builder.buildADF(tokens);
+
+      expect(adf.content).toHaveLength(1);
+      const taskList = adf.content[0];
+      expect(taskList.type).toBe('taskList');
+
+      const taskItem = taskList.content![0];
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs!.state).toBe('DONE');
+    });
+
+    it('should convert token with checked: false to taskItem state=TODO', () => {
+      const tokens = listToken([{ checked: false, text: 'Todo' }]);
+      const adf = builder.buildADF(tokens);
+
+      const taskItem = adf.content[0].content![0];
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs!.state).toBe('TODO');
+    });
+
+    it('should produce taskList when list tokens have checked property', () => {
+      const tokens = listToken([
+        { checked: true, text: 'A' },
+        { checked: false, text: 'B' }
+      ]);
+      const adf = builder.buildADF(tokens);
+
+      expect(adf.content).toHaveLength(1);
+      expect(adf.content[0].type).toBe('taskList');
+      expect(adf.content[0].content).toHaveLength(2);
+    });
+
+    it('should produce bulletList when tokens have no checked property', () => {
+      const tokens = listToken([
+        { text: 'Regular 1' },
+        { text: 'Regular 2' }
+      ]);
+      const adf = builder.buildADF(tokens);
+
+      expect(adf.content).toHaveLength(1);
+      expect(adf.content[0].type).toBe('bulletList');
+    });
+
+    it('should generate unique localIds on taskList and taskItems', () => {
+      const tokens = listToken([
+        { checked: true, text: 'X' },
+        { checked: false, text: 'Y' }
+      ]);
+      const adf = builder.buildADF(tokens);
+
+      const taskList = adf.content[0];
+      const ids = [taskList.attrs!.localId as string];
+      for (const item of taskList.content!) {
+        ids.push(item.attrs!.localId as string);
+      }
+
+      // All non-empty and unique
+      for (const id of ids) {
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThan(0);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('should fall back to bulletList when items are complex (nested children)', () => {
+      const pos = { line: 1, column: 1, offset: 0 };
+      // Complex item: has a nested list child (not just a single paragraph)
+      const tokens: Token[] = [{
+        type: 'list' as const,
+        ordered: false,
+        tight: true,
+        content: '',
+        position: pos,
+        raw: '',
+        children: [{
+          type: 'listItem' as const,
+          content: 'Task text',
+          checked: true,
+          position: pos,
+          raw: '',
+          children: [
+            { type: 'paragraph' as const, content: 'Task text', position: pos, raw: '' },
+            { type: 'list' as const, content: '', position: pos, raw: '', children: [] }
+          ]
+        } as any]
+      } as any];
+
+      const adf = builder.buildADF(tokens);
+      // Should fall back to bulletList since item has complex content
+      expect(adf.content[0].type).toBe('bulletList');
+      const listItem = adf.content[0].content![0];
+      expect(listItem.type).toBe('listItem');
+    });
+
+    it('should preserve checkbox text via content fallback when item has no children', () => {
+      const pos = { line: 1, column: 1, offset: 0 };
+      // Item with checked but no simple paragraph child - uses content string fallback
+      // This tests the re-prepend logic: when falling back, [x] is added to content
+      const tokens: Token[] = [{
+        type: 'list' as const,
+        ordered: false,
+        tight: true,
+        content: '',
+        position: pos,
+        raw: '',
+        children: [
+          {
+            type: 'listItem' as const,
+            content: 'Checked task',
+            checked: true,
+            position: pos,
+            raw: '',
+            // Two children makes it "complex" (not simple), triggering fallback
+            children: [
+              { type: 'paragraph' as const, content: 'First para', position: pos, raw: '' },
+              { type: 'paragraph' as const, content: 'Second para', position: pos, raw: '' }
+            ]
+          } as any
+        ]
+      } as any];
+
+      const adf = builder.buildADF(tokens);
+      expect(adf.content[0].type).toBe('bulletList');
+
+      // The re-prepend modifies itemToken.content to "[x] Checked task"
+      // Verify the token content was modified (the re-prepend happened)
+      const itemToken = (tokens[0] as any).children[0] as ListItemToken;
+      expect(itemToken.content).toContain('[x]');
+    });
+  });
+});

--- a/tests/unit/parser/MarkdownTokenizer.task-list.test.ts
+++ b/tests/unit/parser/MarkdownTokenizer.task-list.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @file MarkdownTokenizer.task-list.test.ts
+ * @description Tests for MarkdownTokenizer checkbox/task-list detection in parseListItem
+ */
+
+import { MarkdownTokenizer } from '../../../src/parser/markdown-to-adf/MarkdownTokenizer.js';
+import type { ListItemToken } from '../../../src/parser/markdown-to-adf/types.js';
+
+describe('MarkdownTokenizer - Task List / Checkbox Detection', () => {
+  let tokenizer: MarkdownTokenizer;
+
+  beforeEach(() => {
+    tokenizer = new MarkdownTokenizer();
+  });
+
+  describe('Checkbox detection in list items', () => {
+    it('should detect checked checkbox: "- [x] Done task"', () => {
+      const tokens = tokenizer.tokenize('- [x] Done task');
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].type).toBe('list');
+
+      const listItems = tokens[0].children;
+      expect(listItems).toBeDefined();
+      expect(listItems).toHaveLength(1);
+
+      const item = listItems![0] as ListItemToken;
+      expect(item.type).toBe('listItem');
+      expect(item.checked).toBe(true);
+      // Content should have the checkbox prefix stripped
+      expect(item.content).not.toMatch(/^\[x\]/);
+      expect(item.content).toContain('Done task');
+    });
+
+    it('should detect unchecked checkbox: "- [ ] Pending task"', () => {
+      const tokens = tokenizer.tokenize('- [ ] Pending task');
+
+      expect(tokens).toHaveLength(1);
+      const listItems = tokens[0].children;
+      expect(listItems).toHaveLength(1);
+
+      const item = listItems![0] as ListItemToken;
+      expect(item.type).toBe('listItem');
+      expect(item.checked).toBe(false);
+      expect(item.content).not.toMatch(/^\[ \]/);
+      expect(item.content).toContain('Pending task');
+    });
+
+    it('should detect uppercase X checkbox: "- [X] Done"', () => {
+      const tokens = tokenizer.tokenize('- [X] Done');
+
+      expect(tokens).toHaveLength(1);
+      const item = tokens[0].children![0] as ListItemToken;
+      expect(item.type).toBe('listItem');
+      expect(item.checked).toBe(true);
+      expect(item.content).toContain('Done');
+    });
+
+    it('should NOT set checked property on regular list items', () => {
+      const tokens = tokenizer.tokenize('- Normal item');
+
+      expect(tokens).toHaveLength(1);
+      const item = tokens[0].children![0] as ListItemToken;
+      expect(item.type).toBe('listItem');
+      expect(item.checked).toBeUndefined();
+      expect(item.content).toContain('Normal item');
+    });
+
+    it('should handle mixed list with checkbox and regular items', () => {
+      const markdown = '- [x] Checked\n- Regular\n- [ ] Unchecked';
+      const tokens = tokenizer.tokenize(markdown);
+
+      expect(tokens).toHaveLength(1);
+      const items = tokens[0].children!;
+      expect(items).toHaveLength(3);
+
+      expect((items[0] as ListItemToken).checked).toBe(true);
+      expect((items[1] as ListItemToken).checked).toBeUndefined();
+      expect((items[2] as ListItemToken).checked).toBe(false);
+    });
+
+    it('should strip checkbox prefix from content text', () => {
+      const tokens = tokenizer.tokenize('- [x] Task text here');
+
+      const item = tokens[0].children![0] as ListItemToken;
+      // The content field should contain the text without the [x] prefix
+      expect(item.content).toBe('Task text here');
+    });
+
+    it('should strip unchecked checkbox prefix from content text', () => {
+      const tokens = tokenizer.tokenize('- [ ] Another task');
+
+      const item = tokens[0].children![0] as ListItemToken;
+      expect(item.content).toBe('Another task');
+    });
+  });
+
+  describe('Token type remains listItem', () => {
+    it('should produce listItem tokens regardless of checkbox state', () => {
+      const markdown = '- [x] Done\n- [ ] Todo\n- Normal';
+      const tokens = tokenizer.tokenize(markdown);
+
+      const items = tokens[0].children!;
+      for (const item of items) {
+        expect(item.type).toBe('listItem');
+      }
+    });
+  });
+
+  describe('List-level token type', () => {
+    it('should produce a list token for checkbox lists', () => {
+      const tokens = tokenizer.tokenize('- [x] Task');
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].type).toBe('list');
+      expect((tokens[0] as any).ordered).toBe(false);
+    });
+  });
+});

--- a/tests/unit/parser/task-list-conversion.test.ts
+++ b/tests/unit/parser/task-list-conversion.test.ts
@@ -1,0 +1,318 @@
+/**
+ * @file Integration tests for task list conversion (MD <-> ADF)
+ * Tests both markdown-to-ADF and ADF-to-markdown conversion paths
+ * using the Parser class directly.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { Parser } from '../../../src/parser/Parser';
+import type { ADFDocument, TaskListNode, TaskItemNode } from '../../../src/types';
+
+describe('Task List Conversion', () => {
+  const parser = new Parser();
+
+  describe('Markdown to ADF', () => {
+    it('should convert "- [x] Done" to taskList with taskItem state=DONE', () => {
+      const markdown = '- [x] Done';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.type).toBe('doc');
+      expect(adf.content).toHaveLength(1);
+
+      const taskList = adf.content[0] as TaskListNode;
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.attrs).toBeDefined();
+      expect(taskList.attrs.localId).toBeDefined();
+      expect(taskList.content).toHaveLength(1);
+
+      const taskItem = taskList.content[0] as TaskItemNode;
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs.state).toBe('DONE');
+      expect(taskItem.attrs.localId).toBeDefined();
+
+      // taskItem content should contain inline text node with "Done"
+      expect(taskItem.content).toBeDefined();
+      expect(taskItem.content!.length).toBeGreaterThanOrEqual(1);
+      const textNode = taskItem.content!.find(n => n.type === 'text');
+      expect(textNode).toBeDefined();
+      expect(textNode!.text).toBe('Done');
+    });
+
+    it('should convert "- [ ] Todo" to taskList with taskItem state=TODO', () => {
+      const markdown = '- [ ] Todo';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.content).toHaveLength(1);
+
+      const taskList = adf.content[0] as TaskListNode;
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.content).toHaveLength(1);
+
+      const taskItem = taskList.content[0] as TaskItemNode;
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs.state).toBe('TODO');
+
+      const textNode = taskItem.content!.find(n => n.type === 'text');
+      expect(textNode).toBeDefined();
+      expect(textNode!.text).toBe('Todo');
+    });
+
+    it('should convert mixed checkbox list to single taskList with mixed states', () => {
+      const markdown = '- [x] Completed\n- [ ] Pending\n- [x] Also done';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.content).toHaveLength(1);
+
+      const taskList = adf.content[0] as TaskListNode;
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.content).toHaveLength(3);
+
+      expect(taskList.content[0].attrs.state).toBe('DONE');
+      expect(taskList.content[1].attrs.state).toBe('TODO');
+      expect(taskList.content[2].attrs.state).toBe('DONE');
+    });
+
+    it('should keep regular bullet list (no checkboxes) as bulletList', () => {
+      const markdown = '- First item\n- Second item';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.content).toHaveLength(1);
+      expect(adf.content[0].type).toBe('bulletList');
+    });
+
+    it('should handle task items with inline formatting (bold, code)', () => {
+      const markdown = '- [x] **Bold task** with `code`';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.content).toHaveLength(1);
+
+      const taskList = adf.content[0] as TaskListNode;
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.content).toHaveLength(1);
+
+      const taskItem = taskList.content[0] as TaskItemNode;
+      expect(taskItem.type).toBe('taskItem');
+      expect(taskItem.attrs.state).toBe('DONE');
+
+      // Inline formatting should be preserved in content
+      expect(taskItem.content).toBeDefined();
+      expect(taskItem.content!.length).toBeGreaterThanOrEqual(1);
+
+      // Should have text nodes with marks for bold and code
+      const boldNode = taskItem.content!.find(
+        n => n.type === 'text' && n.marks?.some(m => m.type === 'strong')
+      );
+      expect(boldNode).toBeDefined();
+    });
+
+    it('should generate localId attrs on taskList and each taskItem', () => {
+      const markdown = '- [x] Task 1\n- [ ] Task 2';
+      const adf = parser.markdownToAdf(markdown);
+
+      const taskList = adf.content[0] as TaskListNode;
+      expect(typeof taskList.attrs.localId).toBe('string');
+      expect(taskList.attrs.localId.length).toBeGreaterThan(0);
+
+      for (const item of taskList.content) {
+        expect(typeof item.attrs.localId).toBe('string');
+        expect(item.attrs.localId.length).toBeGreaterThan(0);
+      }
+
+      // Each localId should be unique
+      const ids = [taskList.attrs.localId, ...taskList.content.map(i => i.attrs.localId)];
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('taskItem content should be inline nodes, NOT wrapped in paragraph', () => {
+      const markdown = '- [x] Simple text';
+      const adf = parser.markdownToAdf(markdown);
+
+      const taskList = adf.content[0] as TaskListNode;
+      const taskItem = taskList.content[0] as TaskItemNode;
+
+      // Content should NOT be wrapped in a paragraph
+      expect(taskItem.content).toBeDefined();
+      const hasParagraph = taskItem.content!.some(n => n.type === 'paragraph');
+      expect(hasParagraph).toBe(false);
+
+      // Should have inline text node directly
+      const textNode = taskItem.content!.find(n => n.type === 'text');
+      expect(textNode).toBeDefined();
+      expect(textNode!.text).toBe('Simple text');
+    });
+  });
+
+  describe('Edge Cases: Complex Checkbox Items', () => {
+    it('should fall back to bulletList when any checkbox item has multiple paragraphs', () => {
+      const markdown = '- [x] Simple task\n- [ ] Complex task\n\n  Second paragraph';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.content.length).toBeGreaterThanOrEqual(1);
+      // The entire list should fall back to bulletList since second item has multiple paragraphs
+      const listNode = adf.content[0];
+      expect(listNode.type).toBe('bulletList');
+    });
+
+    it('should fall back to bulletList when any checkbox item has nested sub-lists', () => {
+      const markdown = '- [x] Task with sub-list\n  - nested item\n- [ ] Simple task';
+      const adf = parser.markdownToAdf(markdown);
+
+      expect(adf.content.length).toBeGreaterThanOrEqual(1);
+      // Should fall back to bulletList since first item has nested list
+      const listNode = adf.content[0];
+      expect(listNode.type).toBe('bulletList');
+    });
+
+    it('should still convert simple checkbox items correctly', () => {
+      const markdown = '- [x] Simple task 1\n- [ ] Simple task 2';
+      const adf = parser.markdownToAdf(markdown);
+
+      const taskList = adf.content[0] as TaskListNode;
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.content).toHaveLength(2);
+      expect(taskList.content[0].type).toBe('taskItem');
+      expect(taskList.content[1].type).toBe('taskItem');
+    });
+  });
+
+  describe('ADF to Markdown', () => {
+    it('should convert taskList/taskItem DONE to "- [x] text"', () => {
+      const adf: ADFDocument = {
+        version: 1,
+        type: 'doc',
+        content: [
+          {
+            type: 'taskList',
+            attrs: { localId: 'list-1' },
+            content: [
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-1', state: 'DONE' },
+                content: [{ type: 'text', text: 'Completed task' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const markdown = parser.adfToMarkdown(adf);
+      expect(markdown).toContain('- [x] Completed task');
+    });
+
+    it('should convert taskList/taskItem TODO to "- [ ] text"', () => {
+      const adf: ADFDocument = {
+        version: 1,
+        type: 'doc',
+        content: [
+          {
+            type: 'taskList',
+            attrs: { localId: 'list-1' },
+            content: [
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-1', state: 'TODO' },
+                content: [{ type: 'text', text: 'Pending task' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const markdown = parser.adfToMarkdown(adf);
+      expect(markdown).toContain('- [ ] Pending task');
+    });
+
+    it('should convert mixed state taskList correctly', () => {
+      const adf: ADFDocument = {
+        version: 1,
+        type: 'doc',
+        content: [
+          {
+            type: 'taskList',
+            attrs: { localId: 'list-1' },
+            content: [
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-1', state: 'DONE' },
+                content: [{ type: 'text', text: 'Done' }]
+              },
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-2', state: 'TODO' },
+                content: [{ type: 'text', text: 'Todo' }]
+              },
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-3', state: 'DONE' },
+                content: [{ type: 'text', text: 'Also done' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const markdown = parser.adfToMarkdown(adf);
+      expect(markdown).toContain('- [x] Done');
+      expect(markdown).toContain('- [ ] Todo');
+      expect(markdown).toContain('- [x] Also done');
+    });
+  });
+
+  describe('Round-trip', () => {
+    it('MD -> ADF -> MD should preserve checkbox state', () => {
+      const originalMd = '- [x] Completed\n- [ ] Pending';
+      const adf = parser.markdownToAdf(originalMd);
+      const roundTripMd = parser.adfToMarkdown(adf);
+
+      // Should preserve the checked/unchecked state
+      expect(roundTripMd).toContain('- [x] Completed');
+      expect(roundTripMd).toContain('- [ ] Pending');
+    });
+
+    it('ADF -> MD -> ADF should preserve taskList/taskItem structure', () => {
+      const originalAdf: ADFDocument = {
+        version: 1,
+        type: 'doc',
+        content: [
+          {
+            type: 'taskList',
+            attrs: { localId: 'list-1' },
+            content: [
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-1', state: 'DONE' },
+                content: [{ type: 'text', text: 'Task one' }]
+              },
+              {
+                type: 'taskItem',
+                attrs: { localId: 'item-2', state: 'TODO' },
+                content: [{ type: 'text', text: 'Task two' }]
+              }
+            ]
+          }
+        ]
+      };
+
+      const markdown = parser.adfToMarkdown(originalAdf);
+      const roundTripAdf = parser.markdownToAdf(markdown);
+
+      // Should preserve taskList/taskItem structure
+      expect(roundTripAdf.content).toHaveLength(1);
+      const taskList = roundTripAdf.content[0] as TaskListNode;
+      expect(taskList.type).toBe('taskList');
+      expect(taskList.content).toHaveLength(2);
+
+      expect(taskList.content[0].type).toBe('taskItem');
+      expect(taskList.content[0].attrs.state).toBe('DONE');
+      expect(taskList.content[1].type).toBe('taskItem');
+      expect(taskList.content[1].attrs.state).toBe('TODO');
+
+      // Text content should be preserved
+      const text1 = taskList.content[0].content?.find(n => n.type === 'text');
+      expect(text1?.text).toBe('Task one');
+      const text2 = taskList.content[1].content?.find(n => n.type === 'text');
+      expect(text2?.text).toBe('Task two');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #8

## Checkbox task lists (`- [x]`/`- [ ]`) lose check state — converted to plain `bulletList` instead of `taskList`

Markdown checkbox syntax is converted to regular `bulletList`/`listItem` nodes, losing the checked/unchecked state entirely. ADF supports [`taskList`](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/taskList/)/[`taskItem`](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/taskItem/) nodes with a `state` attribute (`TODO`/`DONE`) for this.

**Input:**
```markdown
- [x] Completed task
- [ ] Pending task
```

**Current output:**
```json
{
  "type": "bulletList",
  "content": [
    { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Completed task" }] }] },
    { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Pending task" }] }] }
  ]
}
```

The `[x]` and `[ ]` markers are stripped entirely — no trace remains in the ADF output. The checkbox state is lost.

**Expected output:**
```json
{
  "type": "taskList",
  "attrs": { "localId": "unique-id" },
  "content": [
    { "type": "taskItem", "attrs": { "localId": "unique-id-1", "state": "DONE" }, "content": [{ "type": "text", "text": "Completed task" }] },
    { "type": "taskItem", "attrs": { "localId": "unique-id-2", "state": "TODO" }, "content": [{ "type": "text", "text": "Pending task" }] }
  ]
}
```

---
*This PR was created automatically by iloom.*